### PR TITLE
Add support for multiple API keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ const createKey  = async function createKey(key, creds, region, cli) {
     credentials: creds,
     region
   });
-  //cli.consoleLog(`AddApiKey: ${chalk.yellow(`Creating new api key ${key}`)}`);
+  cli.consoleLog(`AddApiKey: ${chalk.yellow(`Creating new api key ${key}`)}`);
   try {
     const resp = await apigateway.createApiKey({ name: key, enabled: true }).promise();
     cli.consoleLog(`AddApiKey: ${chalk.yellow(`Created new api key ${key}:${resp.id}`)}`);

--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ const createUsagePlan = async function createUsagePlan(name, creds, region, cli)
     credentials: creds,
     region
   });
-  //cli.consoleLog(`AddApiKey: ${chalk.yellow(`Creating new usage plan ${name}`)}`);
+  cli.consoleLog(`AddApiKey: ${chalk.yellow(`Creating new usage plan ${name}`)}`);
   try {
     const resp = await apigateway.createUsagePlan({ name }).promise();
     return resp.id;
@@ -178,7 +178,7 @@ const createUsagePlanKey = async function createUsagePlanKey(apiKeyId, usagePlan
     credentials: creds,
     region
   });
-  //cli.consoleLog(`AddApiKey: ${chalk.yellow(`Associating api key ${apiKeyId} with usage plan ${usagePlanId}`)}`);
+  cli.consoleLog(`AddApiKey: ${chalk.yellow(`Associating api key ${apiKeyId} with usage plan ${usagePlanId}`)}`);
   try {
     const params = {
       keyId: apiKeyId,


### PR DESCRIPTION
This request add the ability to add multiple API keys rather than just a single one.  The changes are pretty simple; logic has been added to iterate an array of keys and the key and usages plans are created per key if needed.