### PR TITLE
Feature to allow api key value

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ custom:
 ```
 Code automatically creates a usage plan called `<api-key-name>-usage-plan`.
 
+### Specifying key values
+
+```yaml
+custom:
+  apiKeys:
+    - name: SomeKey
+      value: your-api-key-that-is-at-least-20-characters-long
+    - name: KeyFromSlsVariables
+      value: ${env:MyKey}
+    - SomeOtherKeyThatAssignsRandomValue
+```
+


### PR DESCRIPTION
Details in the readme update, but for cross-region purposes it is necessary to allow a key value to be specified at deploy time. (you can do so securely via the `env` serverless variable mechanism for instance)

Pretty simple change, full backwards compatible, and they are inter-mixable in usage.