### PR TITLE
fix async bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,8 +308,8 @@ class AddApiKey {
   constructor(serverless, options) {
     this.options = options;
     this.hooks = {
-      'after:deploy:deploy': function () {
-        addApiKey(serverless);
+      'after:deploy:deploy': async function () {
+        await addApiKey(serverless);
       }
     };
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-add-api-key",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "serverless plugin to create a api key and usage pattern (if they don't already exist) and associates then to the Rest Api",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I was encountering an issue where the plugin deploy steps were not running to completion and I was seeing API Keys created but not associated with plans or apis. Turns out it was just a missing `async` `await` to ensure Serverless waits for the plugin to complete before exiting.