### PR TITLE
resolve sls stage using built-in method

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,9 +247,10 @@ const associateRestApiWithUsagePlan = async function associateRestApiWithUsagePl
  * @param {Object} serverless Serverless object
  */
 const addApiKey = async function addApiKey(serverless) {
-
-  const awsCredentials = serverless.getProvider('aws').getCredentials();
-  const region = serverless.getProvider('aws').getRegion();
+  const provider = serverless.getProvider('aws');
+  const awsCredentials = provider.getCredentials();
+  const region = provider.getRegion();
+  const stage = provider.getStage();
   const apiKeyNames = serverless.service.custom.apiKeys || [];
   const planName = `${apiKeyName}-usage-plan`;
   const serviceName = serverless.service.getServiceName();
@@ -294,7 +295,7 @@ const addApiKey = async function addApiKey(serverless) {
             serverless.cli.consoleLog(`AddApiKey: ${chalk.yellow(`Usage plan ${planName} already has api key associated with it, skipping association.`)}`);
           }
         }
-        await associateRestApiWithUsagePlan(serviceName, usagePlan, serverless.service.provider.stage, awsCredentials.credentials, region, serverless.cli);
+        await associateRestApiWithUsagePlan(serviceName, usagePlan, stage, awsCredentials.credentials, region, serverless.cli);
       } catch (error) {
         serverless.cli.consoleLog(`AddApiKey: ${chalk.yellow(`Failed to add api key the service. Error ${error.message || error}`)}`);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-add-api-key",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "serverless plugin to create a api key and usage pattern (if they don't already exist) and associates then to the Rest Api",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Sls stage and region can be overridden on the command line. If this happens `serverless.service.provider` will not reflect the passed in stage. This can cause failures since the serverless stack name includes the stage. Using the builtin `getStage` method that accounts for this to resolve stage.