### PR TITLE
Allow not using stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # serverless-add-api-key
+
 [![serverless](http://public.serverless.com/badges/v3.svg)](http://www.serverless.com)
 
 A [serverless](http://www.serverless.com) plugin to create api key and usage pattern (if they don't already exist) and associate them to the Rest Api.
@@ -7,7 +8,7 @@ This plugin associates your Serverless service with same api key if the key alre
 
 The plugin supports serverless stages, so you can create key(s) with different name in different stage.
 
-*__P.S.__ The plugin by default displays the created key and value on the console. If you wish to avoid that then specify `--conceal` option with `sls deploy` command*
+_**P.S.** The plugin by default displays the created key and value on the console. If you wish to avoid that then specify `--conceal` option with `sls deploy` command_
 
 ## Install
 
@@ -22,37 +23,48 @@ plugins:
 
 ## Configuration
 
-### Specifying key(s) and let AWS auto set the value.
+### Specifying key(s) and let AWS auto set the value
+
 ```yaml
 custom:
   apiKeys:
-    dev: # dev is the default stage, so even if you don't use stages please specify the key names under dev
+    - name: name1
+    - name: name2
+```
+
+### Specifying key values
+
+```yaml
+custom:
+  apiKeys:
+    - name: SomeKey
+      value: your-api-key-that-is-at-least-20-characters-long
+    - name: KeyFromSlsVariables
+      value: ${opt:MyKey}
+    - SomeOtherKeyThatAssignsRandomValue
+```
+
+### Stage-specific configuration
+
+To specifiy different API keys for each stage, nest the configuration in a property with the name of the relevant stage.
+
+```yaml
+custom:
+  apiKeys:
+    dev:
       - name: name1
       - name: name2
     prod:
       - name: name1
     other-stage-name:
       - name: name5
-
-```
-
-### Specifying key values.
-
-```yaml
-custom:
-  apiKeys:
-    dev: # dev is the default stage, so even if you don't use stages please specify the key names and values under dev
-      - name: SomeKey
-        value: your-api-key-that-is-at-least-20-characters-long
-      - name: KeyFromSlsVariables
-        value: ${opt:MyKey}
-      - SomeOtherKeyThatAssignsRandomValue
 ```
 
 ### Specifying encrypted key values
 
 In the case that you do not want to expose your raw API key string in your repository, you could check in the encrypted API key strings using KMS key in a region. To do this, first Use a KMS key in the region from command line to encrypt the key:
-```
+
+```sh
   aws kms encrypt --key-id f7c59c6b-83de-4e80-8011-0fbd6846c695 --plaintext BzQ86PiX9t9UaAQsNWuFHN9oOkiyOwd9yXBu8RF1 | base64 --decode
 ```
 
@@ -61,12 +73,12 @@ Then configure the `value` as { encrypted: "AQICAHinIKhx8yV+y97+qS5naGEBUQrTP8RP
 ```yaml
 custom:
   apiKeys:
-    dev: # dev is the default stage, so even if you don't use stages please specify the key names and values under dev
-      - name: KMSEncryptedKey
-        value:
-          encrypted: A-KMS-Encrypted-Value
-          kmsKeyRegion: us-west-1
+    - name: KMSEncryptedKey
+      value:
+        encrypted: A-KMS-Encrypted-Value
+        kmsKeyRegion: us-west-1
 ```
-When an object with `encrypted` and `kmsKeyRegion` key detected in `value`, the encrypted value will be decrypted using a proper KMS key from the region specified in `kmsKeyRegion`. In the case of missing `kmsKeyRegion`, the region from command line will be used. 
+
+When an object with `encrypted` and `kmsKeyRegion` key detected in `value`, the encrypted value will be decrypted using a proper KMS key from the region specified in `kmsKeyRegion`. In the case of missing `kmsKeyRegion`, the region from command line will be used.
 
 Code automatically creates usage plan called `<api-key-name>-usage-plan`.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const AWS = require('aws-sdk')
-const chalk = require('chalk')
+const AWS = require('aws-sdk');
+const chalk = require('chalk');
 
 /**
  * Get api key by name.
@@ -9,13 +9,13 @@ const chalk = require('chalk')
  * @param {Object} cli Serverless CLI object
  * @returns {Object} Api key info.
  */
-const getApiKey = async function getApiKey(key, creds, region, cli) {
+const getApiKey = async (key, creds, region, cli) => {
   const apigateway = new AWS.APIGateway({
     credentials: creds,
     region
   });
   let position = null;
-  let keys = []
+  let keys = [];
   try {
     while (true) {
       let resp = null;
@@ -32,14 +32,14 @@ const getApiKey = async function getApiKey(key, creds, region, cli) {
       }
     }
     return keys.find(k => k.name === key);
-  } catch(error) {
+  } catch (error) {
     if (error.code === 'NotFoundException') {
       return apiKey;
     }
-    cli.consoleLog(`AddApiKey: ${chalk.yellow(`Failed to check if key already exists. Error ${error.message || error}`)}`)
+    cli.consoleLog(`AddApiKey: ${chalk.yellow(`Failed to check if key already exists. Error ${error.message || error}`)}`);
     throw error;
   }
-}
+};
 
 /**
  * Get usage plan info by name.
@@ -49,7 +49,7 @@ const getApiKey = async function getApiKey(key, creds, region, cli) {
  * @param {Object} cli Serverless CLI object
  * @returns {Object} Usage plan info.
  */
-const getUsagePlan = async function getUsagePlan(planName, creds, region, cli) {
+const getUsagePlan = async (planName, creds, region, cli) => {
   const apigateway = new AWS.APIGateway({
     credentials: creds,
     region
@@ -72,11 +72,11 @@ const getUsagePlan = async function getUsagePlan(planName, creds, region, cli) {
       }
     }
     return plans.find(p => p.name === planName);
-  } catch(error) {
+  } catch (error) {
     if (error.code === 'NotFoundException') {
       return usagePlan;
     }
-    cli.consoleLog(`AddApiKey: ${chalk.yellow(`Failed to check if usage plan already exists. Error ${error.message || error}`)}`)
+    cli.consoleLog(`AddApiKey: ${chalk.yellow(`Failed to check if usage plan already exists. Error ${error.message || error}`)}`);
     throw error;
   }
 };
@@ -89,13 +89,13 @@ const getUsagePlan = async function getUsagePlan(planName, creds, region, cli) {
  * @param {Object} cli Serverless CLI object
  * @returns {Array} List of Api keys associated with the usage plan.
  */
-const getUsagePlanKeys = async function getUsagePlanKeys(usagePlanId, creds, region, cli) {
+const getUsagePlanKeys = async (usagePlanId, creds, region, cli) => {
   const apigateway = new AWS.APIGateway({
     credentials: creds,
     region
   });
   let position = null;
-  let planKeys = []
+  let planKeys = [];
   try {
     while (true) {
       let resp = null;
@@ -112,8 +112,8 @@ const getUsagePlanKeys = async function getUsagePlanKeys(usagePlanId, creds, reg
       }
     }
     return planKeys;
-  } catch(error) {
-    cli.consoleLog(`AddApiKey: ${chalk.yellow(`Failed to check if usage plan already exists. Error ${error.message || error}`)}`)
+  } catch (error) {
+    cli.consoleLog(`AddApiKey: ${chalk.yellow(`Failed to check if usage plan already exists. Error ${error.message || error}`)}`);
     throw error;
   }
 };
@@ -127,7 +127,7 @@ const getUsagePlanKeys = async function getUsagePlanKeys(usagePlanId, creds, reg
  * @param {Object} cli Serverless CLI object
  * @returns {string} Api key id.
  */
-const createKey  = async function createKey(key, keyValue, creds, region, cli) {
+const createKey = async (key, keyValue, creds, region, cli) => {
   const apigateway = new AWS.APIGateway({
     credentials: creds,
     region
@@ -135,7 +135,7 @@ const createKey  = async function createKey(key, keyValue, creds, region, cli) {
   cli.consoleLog(`AddApiKey: ${chalk.yellow(`Creating new api key ${key}`)}`);
   try {
     const params = { name: key, enabled: true };
-    if(keyValue) params.value = keyValue;
+    if (keyValue) params.value = keyValue;
 
     const resp = await apigateway.createApiKey(params).promise();
     cli.consoleLog(`AddApiKey: ${chalk.yellow(`Created new api key ${key}:${resp.id}`)}`);
@@ -154,7 +154,7 @@ const createKey  = async function createKey(key, keyValue, creds, region, cli) {
  * @param {Object} cli Serverless CLI object
  * @returns {string} Usage plan id.
  */
-const createUsagePlan = async function createUsagePlan(name, creds, region, cli) {
+const createUsagePlan = async (name, creds, region, cli) => {
   const apigateway = new AWS.APIGateway({
     credentials: creds,
     region
@@ -177,7 +177,7 @@ const createUsagePlan = async function createUsagePlan(name, creds, region, cli)
  * @param {string} region AWS region.
  * @param {Object} cli Serverless CLI object
  */
-const createUsagePlanKey = async function createUsagePlanKey(apiKeyId, usagePlanId, creds, region, cli) {
+const createUsagePlanKey = async (apiKeyId, usagePlanId, creds, region, cli) => {
   const apigateway = new AWS.APIGateway({
     credentials: creds,
     region
@@ -194,7 +194,7 @@ const createUsagePlanKey = async function createUsagePlanKey(apiKeyId, usagePlan
     cli.consoleLog(`AddApiKey: ${chalk.yellow(`Failed to associate api key with usage plan. Error ${error.message || error}`)}`);
     throw error;
   }
-}
+};
 
 /**
  * Add Api gateway to usage plan.
@@ -205,7 +205,7 @@ const createUsagePlanKey = async function createUsagePlanKey(apiKeyId, usagePlan
  * @param {string} region AWS region.
  * @param {Object} cli Serverless CLI object
  */
-const associateRestApiWithUsagePlan = async function associateRestApiWithUsagePlan(serviceName, usagePlan, stage, creds, region, cli) {
+const associateRestApiWithUsagePlan = async (serviceName, usagePlan, stage, creds, region, cli) => {
   const cfn = new AWS.CloudFormation({
     credentials: creds,
     region
@@ -232,7 +232,7 @@ const associateRestApiWithUsagePlan = async function associateRestApiWithUsagePl
         value: `${apiName}:${stage}`
       }
     ]
-  }
+  };
 
   const ag = new AWS.APIGateway({
     credentials: creds,
@@ -240,15 +240,15 @@ const associateRestApiWithUsagePlan = async function associateRestApiWithUsagePl
   });
   await ag.updateUsagePlan(params).promise();
   cli.consoleLog(`AddApiKey: ${chalk.yellow(`Completed associating rest Api ${apiName} with the usage plan`)}`);
-}
+};
 
 /**
- * 
+ *
  * @param {string} encryptedApiKeyValue Encrypted value for the API key
  * @param {string} kmsKeyRegion AWS region where KMS key is in.
  * @param {Object} cli Serverless CLI object
  */
-const decryptApiKeyValue = async function decryptApiKeyValue(encryptedApiKeyValue, kmsKeyRegion, cli) {
+const decryptApiKeyValue = async (encryptedApiKeyValue, kmsKeyRegion, cli) => {
   const kms = new AWS.KMS({ apiVersion: '2014-11-01', region: kmsKeyRegion });
   try {
     const decryptedApiKeyValue = await kms
@@ -256,42 +256,41 @@ const decryptApiKeyValue = async function decryptApiKeyValue(encryptedApiKeyValu
       .promise()
       .then(data => data.Plaintext.toString('ascii'));
 
-      cli.consoleLog(`AddApiKey: ${chalk.yellow(`Successfully decrypted value of "${encryptedApiKeyValue.substring(0, 10)}..." using KMS key in ${kmsKeyRegion}`)}`);
-      return decryptedApiKeyValue;
+    cli.consoleLog(`AddApiKey: ${chalk.yellow(`Successfully decrypted value of "${encryptedApiKeyValue.substring(0, 10)}..." using KMS key in ${kmsKeyRegion}`)}`);
+    return decryptedApiKeyValue;
   } catch (error) {
     cli.consoleLog(`AddApiKey: ${chalk.yellow(`Value "${encryptedApiKeyValue.substring(0, 10)}..." can not be decrypted properly with keys in KMS in region ${kmsKeyRegion}`)}. The value for the key will be generated.`);
-    throw error;       
+    throw error;
   }
-}
+};
 
 /**
  * Main function that adds api key.
  * @param {Object} serverless Serverless object
  */
-const addApiKey = async function addApiKey(serverless, options) {
+const addApiKey = async (serverless, options) => {
   const provider = serverless.getProvider('aws');
   const awsCredentials = provider.getCredentials();
   const region = provider.getRegion();
   const stage = provider.getStage();
-  console.log(stage);
   const conceal = options.conceal;
-  const apiKeysForStages = serverless.service.custom.apiKeys;
-  const apiKeys = apiKeysForStages ? apiKeysForStages[stage] : []
+  const apiKeysForStages = serverless.service.custom.apiKeys || [];
+  const apiKeys = Array.isArray(apiKeysForStages) ? apiKeysForStages : apiKeysForStages[stage];
   const serviceName = serverless.service.getServiceName();
 
   const results = [];
 
-  if (!apiKeys.length) {
+  if (!apiKeys || !apiKeys.length) {
     serverless.cli.consoleLog(`AddApiKey: ${chalk.yellow(`No ApiKey names specified for stage ${stage} so skipping creation`)}`);
   }
 
   for (let apiKey of apiKeys) {
     let apiKeyValue = null;
     const apiKeyName = apiKey.name;
-    if(apiKey.value){
+    if (apiKey.value) {
       apiKeyValue = apiKey.value;
       // if KMS encrypted value configured, encrypt it using KMS
-      if(typeof apiKeyValue === 'object' && apiKeyValue.encrypted) {
+      if (typeof apiKeyValue === 'object' && apiKeyValue.encrypted) {
         // use region specified for KMS keys, otherwise take the region from command line
         const kmsKeyRegion = apiKeyValue.kmsKeyRegion || region;
         apiKeyValue = await decryptApiKeyValue(apiKeyValue.encrypted, kmsKeyRegion, serverless.cli);
@@ -299,7 +298,6 @@ const addApiKey = async function addApiKey(serverless, options) {
     }
 
     try {
-
       const planName = `${apiKeyName}-usage-plan`;
       const apiKey = await getApiKey(apiKeyName, awsCredentials.credentials, region, serverless.cli);
       let usagePlan = await getUsagePlan(planName, awsCredentials.credentials, region, serverless.cli);
@@ -312,12 +310,10 @@ const addApiKey = async function addApiKey(serverless, options) {
         const { id, value } = await createKey(apiKeyName, apiKeyValue, awsCredentials.credentials, region, serverless.cli);
         apiKeyId = id;
         if (!conceal) {
-          results.push(
-            {
-              key: apiKeyName,
-              value
-            }
-          );
+          results.push({
+            key: apiKeyName,
+            value
+          });
         }
       } else {
         serverless.cli.consoleLog(`AddApiKey: ${chalk.yellow(`Api key ${apiKeyName} already exists, skipping creation.`)}`);
@@ -355,9 +351,7 @@ class AddApiKey {
   constructor(serverless, options) {
     this.options = options;
     this.hooks = {
-      'after:deploy:deploy': async function () {
-        await addApiKey(serverless, options);
-      }
+      'after:deploy:deploy': () => addApiKey(serverless, options)
     };
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-add-api-key",
-  "version": "2.1.5",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,9 +13,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.388.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.388.0.tgz",
-      "integrity": "sha512-2yycFVn90H61R3vbE+4Yqn8AEOS88oOE1wUsm6aUhsk+i/Y707a85C166gKuE3+if4y8IS5qqQJiX+HUtF0KNw==",
+      "version": "2.421.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.421.0.tgz",
+      "integrity": "sha512-N0vY++NJc0MV96pu4vcnJIe8MXNKgcNLxlRPDALlIbaYHSC+btJSAdXpC5+4uFFF30uWCaIM1WiX8O/9Obg5oA==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-add-api-key",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "serverless plugin to create a api key and usage pattern (if they don't already exist) and associates then to the Rest Api",
   "main": "index.js",
   "scripts": {
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/rrahul963/serverless-add-api-key#readme",
   "dependencies": {
-    "aws-sdk": "^2.245.1",
+    "aws-sdk": "^2.421.0",
     "chalk": "^2.4.1"
   }
 }


### PR DESCRIPTION
I have a use-case where the stages are dynamic for the creation of temporary review-environments etc. so the current format of stages does not work as I'd like to be able to do the following:
```yaml
  apiKeys:
    - name: API-Key-${opt:stage, self:provider.stage}
      value: ${ssm:/app/${opt:stage, self:provider.stage}/apiKey~true}
```
This means the serverless.yml does not need to be edited for the creation of a new stage.

I also took the liberty to run a linter on your code and refactor it accordingly...