### PR TITLE
Respect provider.stackName in serverless.yml

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,7 +278,6 @@ const addApiKey = async (serverless, options) => {
   const apiKeys = Array.isArray(apiKeysForStages) ? apiKeysForStages : apiKeysForStages[stage];
   const serviceName = serverless.service.getServiceName();
   const stackName = serverless.service.provider.stackName || `${serviceName}-${stage}`;
-git
   const results = [];
 
   if (!apiKeys || !apiKeys.length) {

--- a/index.js
+++ b/index.js
@@ -205,12 +205,12 @@ const createUsagePlanKey = async (apiKeyId, usagePlanId, creds, region, cli) => 
  * @param {string} region AWS region.
  * @param {Object} cli Serverless CLI object
  */
-const associateRestApiWithUsagePlan = async (serviceName, usagePlan, stage, creds, region, cli) => {
+const associateRestApiWithUsagePlan = async (stackName, usagePlan, stage, creds, region, cli) => {
   const cfn = new AWS.CloudFormation({
     credentials: creds,
     region
   });
-  const stack = await cfn.describeStacks({ StackName: `${serviceName}-${stage}` }).promise();
+  const stack = await cfn.describeStacks({ StackName: `${stackName}` }).promise();
   const { Outputs } = stack.Stacks[0];
   let apiName = null;
   Outputs.forEach(o => {
@@ -277,7 +277,8 @@ const addApiKey = async (serverless, options) => {
   const apiKeysForStages = serverless.service.custom.apiKeys || [];
   const apiKeys = Array.isArray(apiKeysForStages) ? apiKeysForStages : apiKeysForStages[stage];
   const serviceName = serverless.service.getServiceName();
-
+  const stackName = serverless.service.provider.stackName || `${serviceName}-${stage}`;
+git
   const results = [];
 
   if (!apiKeys || !apiKeys.length) {
@@ -336,7 +337,7 @@ const addApiKey = async (serverless, options) => {
           serverless.cli.consoleLog(`AddApiKey: ${chalk.yellow(`Usage plan ${planName} already has api key associated with it, skipping association.`)}`);
         }
       }
-      await associateRestApiWithUsagePlan(serviceName, usagePlan, stage, awsCredentials.credentials, region, serverless.cli);
+      await associateRestApiWithUsagePlan(stackName, usagePlan, stage, awsCredentials.credentials, region, serverless.cli);
     } catch (error) {
       serverless.cli.consoleLog(`AddApiKey: ${chalk.yellow(`Failed to add api key the service. Error ${error.message || error}`)}`);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-add-api-key",
-  "version": "3.2.1-beta",
+  "version": "3.2.1",
   "description": "serverless plugin to create a api key and usage pattern (if they don't already exist) and associates then to the Rest Api",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-add-api-key",
-  "version": "3.2.0",
+  "version": "3.2.1-beta",
   "description": "serverless plugin to create a api key and usage pattern (if they don't already exist) and associates then to the Rest Api",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Use provider.stackName if provided otherwise fall back on default stack name.