### PR TITLE
Use the httpOptions that have been created by serverless

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -282,12 +282,14 @@ const addApiKey = async (serverless, options) => {
   const results = [];
   const ag = new AWS.APIGateway({
     credentials: awsCredentials.credentials,
-    region
+    region,
+    httpOptions: provider.sdk.config.httpOptions
   });
 
   const cfn = new AWS.CloudFormation({
     credentials: awsCredentials.credentials,
-    region
+    region,
+    httpOptions: provider.sdk.config.httpOptions
   });
 
   if (!apiKeys || !apiKeys.length) {


### PR DESCRIPTION
This will enable proxy support for those who are behind a corporate proxy.