### PR TITLE
Recognize `provider.apiGateway.usagePlan` (support Serverless Framework v3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-add-api-key",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "serverless plugin to create a api key and usage pattern (if they don't already exist) and associates them to the Rest Api",
   "main": "src/index.js",
   "scripts": {

--- a/src/helper.js
+++ b/src/helper.js
@@ -265,6 +265,12 @@ const deleteApiKey = async function deleteApiKey(id, ag, cli) {
   }
 };
 
+const resolveDefaultUsagePlan = provider => {
+  if (!provider) return {};
+  if (provider.apiGateway && provider.apiGateway.usagePlan) return provider.apiGateway.usagePlan;
+  return provider.usagePlan || {};
+}
+
 /**
  * Main function that adds api key.
  * @param {Object} serverless Serverless object
@@ -297,7 +303,7 @@ const addApiKey = async (serverless, options) => {
   }
 
   let planName;
-  const defaultUsagePlan = (serverless.service.provider && serverless.service.provider.usagePlan) || {};
+  const defaultUsagePlan = resolveDefaultUsagePlan(serverless.service.provider);
 
   for (let apiKey of apiKeys) {
     let apiKeyValue = null;
@@ -393,7 +399,7 @@ const removeApiKey = async (serverless) => {
   });
 
   let planName;
-  const defaultUsagePlan = (serverless.service.provider && serverless.service.provider.usagePlan) || {};
+  const defaultUsagePlan = resolveDefaultUsagePlan(serverless.service.provider);
 
   for (let apiKey of apiKeys) {
     const apiKeyName = apiKey.name;


### PR DESCRIPTION
Fixes https://github.com/rrahul963/serverless-add-api-key/issues/44

Starting with v3 release of the Framework `provider.usagePlan` will no longer be recognized. This patch ensures that plugin remains compatible with Framework v3 release