### PR TITLE
fix: skip addApiKey for undefined stage.

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -300,6 +300,7 @@ const addApiKey = async (serverless, options) => {
 
   if (!apiKeys || !apiKeys.length) {
     serverless.cli.consoleLog(`AddApiKey: ${chalk.yellow(`No ApiKey names specified for stage ${stage} so skipping creation`)}`);
+    return;
   }
 
   let planName;


### PR DESCRIPTION
The condition exists and makes the log, but it continue execution and does not exit the function.